### PR TITLE
Integration of Flow Rates for WK Model

### DIFF
--- a/src/configuration/SimConfig.cc
+++ b/src/configuration/SimConfig.cc
@@ -703,6 +703,10 @@ namespace hemelb
 		      const io::xml::Element radiusEl = conditionEl.GetChildOrThrow("radius");
 		      newIolet->SetRadius(GetDimensionalValueInLatticeUnits<LatticeDistance>(radiusEl, "m"));
 
+			  distribn_t tempArea;
+		      GetDimensionalValue(conditionEl.GetChildOrThrow("area"), "m^2", tempArea);
+		      newIolet->SetArea(unitConverter->ConvertAreaToLatticeUnits(tempArea));
+
 		      return newIolet;
 		}
 

--- a/src/lb/iolets/BoundaryComms.cc
+++ b/src/lb/iolets/BoundaryComms.cc
@@ -16,11 +16,10 @@ namespace hemelb
     namespace iolets
     {
 
-      BoundaryComms::BoundaryComms(SimulationState* iSimState, std::vector<int> &iProcsList, int centreRank, const BoundaryCommunicator& boundaryComm) :
-          nProcs((int) iProcsList.size()), procsList(iProcsList), centreRank(centreRank), bcComm(boundaryComm)
+      BoundaryComms::BoundaryComms(SimulationState* iSimState, int centreRank, const BoundaryCommunicator& boundaryComm) :
+          nProcs(boundaryComm.Size()), bcComm(boundaryComm)
       {
-        /* iProcsList contains the procs containing said Boundary/iolet, but NOT proc 0! */
-        // Let centreRank be the BoundaryControlling/BC proc
+        // Let centreRank be the BoundaryControlling(BC) proc
         bcComm.SetBCProcRank(centreRank);
 
         // Only BC proc sends
@@ -79,7 +78,7 @@ namespace hemelb
                     density,
                     1,
                     net::MpiDataType(*density),
-                    procsList[proc],
+                    proc,
                     100,
                     bcComm,
                     &sendRequest[proc]
@@ -90,19 +89,16 @@ namespace hemelb
 
       void BoundaryComms::Receive(distribn_t* density)
       {
-        if (bcComm.Rank() != 0)
-        {
-          HEMELB_MPI_CALL(
-              MPI_Irecv, (
-                  density,
-                  1,
-                  net::MpiDataType(*density),
-                  bcComm.GetBCProcRank(),
-                  100,
-                  bcComm,
-                  &receiveRequest
-              ));
-        }
+        HEMELB_MPI_CALL(
+            MPI_Irecv, (
+                density,
+                1,
+                net::MpiDataType(*density),
+                bcComm.GetBCProcRank(),
+                100,
+                bcComm,
+                &receiveRequest
+            ));
       }
 
       void BoundaryComms::FinishSend()

--- a/src/lb/iolets/BoundaryComms.h
+++ b/src/lb/iolets/BoundaryComms.h
@@ -22,7 +22,7 @@ namespace hemelb
       class BoundaryComms
       {
         public:
-          BoundaryComms(SimulationState* iSimState, std::vector<int> &iProcsList, int centreRank, const BoundaryCommunicator& boundaryComm);
+          BoundaryComms(SimulationState* iSimState, int centreRank, const BoundaryCommunicator& boundaryComm);
           ~BoundaryComms();
 
           void Wait();
@@ -35,13 +35,9 @@ namespace hemelb
           {
             return nProcs;
           }
-          const std::vector<int>& GetListOfProcs() const
+          const BoundaryCommunicator& GetCommunicator() const
           {
-            return procsList;
-          }
-          int GetCentreRank() const
-          {
-            return centreRank;
+            return bcComm;
           }
 
           void ReceiveDoubles(double* double_array, int size);
@@ -53,8 +49,6 @@ namespace hemelb
           bool hasBoundary;
 
           int nProcs;
-          std::vector<int> procsList;
-          int centreRank; //The rank that contains the centre site of the iolet
 
           BoundaryCommunicator bcComm;
 

--- a/src/lb/iolets/BoundaryValues.cc
+++ b/src/lb/iolets/BoundaryValues.cc
@@ -55,9 +55,16 @@ namespace hemelb
 
             if (iolet->IsCommsRequired()) //DEREK: POTENTIAL MULTISCALE ISSUE (this if-statement)
             {
-              // Here we assume that an iolet has a single rank holding the centre. If more than one rank is valid we pass the 
-              // first one from the centreList and the other(s) remain as slaves to this one...
-              iolet->SetComms(new BoundaryComms(state, procsList[ioletIndex], centreList[ioletIndex][0], bcComms));	
+              // Create a local communicator at the iolet
+              net::MpiGroup new_group = bcComms.Group().Include(procsList[ioletIndex]);
+              net::MpiCommunicator new_comm = bcComms.CreateGroup(new_group, ioletIndex);
+
+              // Find the rank that contains the centre site in the local communicator
+              std::vector<int>::iterator it = std::find(procsList[ioletIndex].begin(), \
+                  procsList[ioletIndex].end(), centreList[ioletIndex][0]);
+              int centreRank = std::distance(procsList[ioletIndex].begin(), it);
+
+              iolet->SetComms(new BoundaryComms(state, centreRank, new_comm));
             }
           }
         }

--- a/src/lb/iolets/InOutLet.cc
+++ b/src/lb/iolets/InOutLet.cc
@@ -17,6 +17,7 @@ namespace hemelb
       }
 
       void InOutLet::DoPreStreamCoupling(const site_t& siteID,
+                                         const LatticeTimeStep& timeStep,
                                          const LatticeVector& sitePos,
                                          const LatticeDensity& density,
                                          const LatticeVelocity& velocity)
@@ -24,7 +25,9 @@ namespace hemelb
         // pass
       }
 
-      void InOutLet::DoPostStreamCoupling(const site_t& siteID, const LatticeVector& sitePos)
+      void InOutLet::DoPostStreamCoupling(const site_t& siteID,
+                                          const LatticeTimeStep& timeStep,
+                                          const LatticeVector& sitePos)
       {
         // pass
       }

--- a/src/lb/iolets/InOutLet.h
+++ b/src/lb/iolets/InOutLet.h
@@ -227,11 +227,14 @@ namespace hemelb
            * Carry out coupling with an external system at the iolet.
            */
           virtual void DoPreStreamCoupling(const site_t& siteID,
+                                           const LatticeTimeStep& timeStep,
                                            const LatticeVector& sitePos,
                                            const LatticeDensity& density,
                                            const LatticeVelocity& velocity);
 
-          virtual void DoPostStreamCoupling(const site_t& siteID, const LatticeVector& sitePos);
+          virtual void DoPostStreamCoupling(const site_t& siteID,
+                                            const LatticeTimeStep& timeStep,
+                                            const LatticeVector& sitePos);
 
         protected:
           LatticeDensity minimumSimulationDensity;

--- a/src/lb/iolets/InOutLetVelocity.cc
+++ b/src/lb/iolets/InOutLetVelocity.cc
@@ -13,7 +13,7 @@ namespace hemelb
     namespace iolets
     {
       InOutLetVelocity::InOutLetVelocity() :
-          radius(0.)
+          InOutLet(), radius(0.)
       {
       }
 

--- a/src/lb/iolets/InOutLetWK.cc
+++ b/src/lb/iolets/InOutLetWK.cc
@@ -55,6 +55,7 @@ namespace hemelb
       }
 
       void InOutLetWK::DoPreStreamCoupling(const site_t& siteID,
+                                           const LatticeTimeStep& timeStep,
                                            const LatticeVector& sitePos,
                                            const LatticeDensity& density,
                                            const LatticeVelocity& velocity)
@@ -76,7 +77,9 @@ namespace hemelb
 				}
       }
 
-      void InOutLetWK::DoPostStreamCoupling(const site_t& siteID, const LatticeVector& sitePos)
+      void InOutLetWK::DoPostStreamCoupling(const site_t& siteID,
+                                            const LatticeTimeStep& timeStep,
+                                            const LatticeVector& sitePos)
       {
         if (siteID == centreSiteID)
         {

--- a/src/lb/iolets/InOutLetWK.cc
+++ b/src/lb/iolets/InOutLetWK.cc
@@ -14,8 +14,9 @@ namespace hemelb
     namespace iolets
     {
       InOutLetWK::InOutLetWK() :
-          InOutLet(), density(1.0), densityNew(1.0), radius(1.0),
-          resistance(1.0), capacitance(1.0)
+          InOutLet(), radius(1.0), area(1.0), resistance(1.0), capacitance(1.0),
+          density(1.0), densityNew(1.0), flowRate(0.0), flowRateNew(0.0),
+          siteCount(0)
       {
       }
 
@@ -31,11 +32,22 @@ namespace hemelb
 
       void InOutLetWK::DoComms(const BoundaryCommunicator& boundaryComm, const LatticeTimeStep timeStep)
       {
-        if (comms->GetNumProcs() == 1) return;
+        if (comms->GetNumProcs() > 1)
+        {
+          comms->Receive(&density);
+          comms->Send(&densityNew);
+          comms->WaitAllComms();
 
-        comms->Receive(&density);
-        comms->Send(&densityNew);
-        comms->WaitAllComms();
+          const BoundaryCommunicator& bcComm = comms->GetCommunicator();
+          flowRate = bcComm.Reduce(flowRateNew, MPI_SUM, bcComm.GetBCProcRank());
+          siteCount = bcComm.Reduce(siteCount, MPI_SUM, bcComm.GetBCProcRank());
+        }
+        if (siteCount != 0)
+        {
+          flowRate = flowRate * area / siteCount;
+        }
+        flowRateNew = 0.0;
+        siteCount = 0;
       }
 
       LatticeDistance InOutLetWK::GetDistanceSquared(const LatticePosition& x) const
@@ -64,17 +76,17 @@ namespace hemelb
 				{
 					LatticePressure pressure = GetPressure(0); // the argument is dummy
 					distribn_t R0 = resistance, C0 = capacitance;
-					distribn_t scaleFactor = GetScaleFactor(sitePos);
-					distribn_t component = velocity.Dot(-normal); // note that outlet normals point inwards
 
 					// Explicit integration scheme
-					//LatticePressure pressureNew = (1.0/C0)*scaleFactor*component + (1.0 - 1.0/(R0*C0))*pressure;
+					//LatticePressure pressureNew = (1.0/C0)*flowRate + (1.0 - 1.0/(R0*C0))*pressure;
 
 					// Semi-implicit integration scheme
-					LatticePressure pressureNew = R0/(1.0 + R0*C0) * (scaleFactor*component + C0*pressure);
+					LatticePressure pressureNew = R0/(1.0 + R0*C0) * (flowRate + C0*pressure);
 
 					densityNew = pressureNew / Cs2;
 				}
+        flowRateNew += velocity.Dot(-normal);
+        siteCount ++;
       }
 
       void InOutLetWK::DoPostStreamCoupling(const site_t& siteID,
@@ -84,6 +96,7 @@ namespace hemelb
         if (siteID == centreSiteID)
         {
           density = densityNew;
+          flowRate = flowRateNew;
         }
       }
     }

--- a/src/lb/iolets/InOutLetWK.h
+++ b/src/lb/iolets/InOutLetWK.h
@@ -64,7 +64,7 @@ namespace hemelb
           }
           
 	        /**
-           * Note that the radius and max speed for these are specified in LATTICE UNITS in the XML file.
+           * Note that the radius and area for these are specified in LATTICE UNITS in the XML file.
            * This is indeed a horrible hack.
            * @return
            */
@@ -76,6 +76,16 @@ namespace hemelb
           void SetRadius(const LatticeDistance& r)
           {
             radius = r;
+          }
+
+          const distribn_t& GetArea() const
+          {
+            return area;
+          }
+
+          void SetArea(const distribn_t& a)
+          {
+            area = a;
           }
         
           virtual distribn_t GetScaleFactor(const LatticePosition& x) const;
@@ -113,10 +123,11 @@ namespace hemelb
                                     const LatticeVector& sitePos);
 
         protected:
-          LatticeDensity density, densityNew;
           LatticeDistance radius;
-          distribn_t resistance;
-          distribn_t capacitance;
+          distribn_t area, resistance, capacitance;
+          LatticeDensity density, densityNew;
+          distribn_t flowRate, flowRateNew;
+          site_t siteCount;
       };
     }
   }

--- a/src/lb/iolets/InOutLetWK.h
+++ b/src/lb/iolets/InOutLetWK.h
@@ -103,11 +103,14 @@ namespace hemelb
           }
 
           void DoPreStreamCoupling(const site_t& siteID,
+                                   const LatticeTimeStep& timeStep,
                                    const LatticeVector& sitePos,
                                    const LatticeDensity& density,
                                    const LatticeVelocity& velocity);
 
-          void DoPostStreamCoupling(const site_t& siteID, const LatticeVector& sitePos);
+          void DoPostStreamCoupling(const site_t& siteID,
+                                    const LatticeTimeStep& timeStep,
+                                    const LatticeVector& sitePos);
 
         protected:
           LatticeDensity density, densityNew;

--- a/src/lb/streamers/LaddIoletDelegate.h
+++ b/src/lb/streamers/LaddIoletDelegate.h
@@ -50,6 +50,10 @@ namespace hemelb
                 dynamic_cast<iolets::InOutLetVelocity*>(bValues->GetIolets()[boundaryId]);
             LatticePosition sitePos(site.GetGlobalSiteCoords());
 
+            // Couple with an external system if there is
+						iolet->DoPreStreamCoupling(site.GetIndex(), bValues->GetTimeStep(), site.GetGlobalSiteCoords(),
+														           hydroVars.density, hydroVars.velocity);
+
             LatticePosition halfWay(sitePos);
             halfWay.x += 0.5 * LatticeType::CX[ii];
             halfWay.y += 0.5 * LatticeType::CY[ii];
@@ -71,6 +75,18 @@ namespace hemelb
                                                                                         ii))) =
                 hydroVars.GetFPostCollision()[ii] - correction;
           }
+
+          inline void PostStepLink(geometry::LatticeData* const latticeData,
+							const geometry::Site<geometry::LatticeData>& site,
+							const Direction& direction)
+					{
+						int boundaryId = site.GetIoletId();
+						iolets::InOutLet* localIOlet = bValues->GetIolets()[boundaryId];
+
+						// Finalise the coupling with the external system
+						localIOlet->DoPostStreamCoupling(site.GetIndex(), bValues->GetTimeStep(), site.GetGlobalSiteCoords());
+					}
+
         private:
           iolets::BoundaryValues* bValues;
       };

--- a/src/lb/streamers/LaddIoletDelegate.h
+++ b/src/lb/streamers/LaddIoletDelegate.h
@@ -27,6 +27,11 @@ namespace hemelb
               SimpleBounceBackDelegate<CollisionType>(delegatorCollider, initParams),
                   bValues(initParams.boundaryObject)
           {
+            // Adapted from YangPressureDelegate
+					  for (int i = 0; i < bValues->GetLocalIoletCount(); ++i)
+					  {
+						  SortDirectionsCloseToIOletNormal(bValues->GetLocalIolet(i));
+					  }
           }
 
           inline void StreamLink(const LbmParameters* lbmParams,
@@ -49,10 +54,14 @@ namespace hemelb
             iolets::InOutLetVelocity* iolet =
                 dynamic_cast<iolets::InOutLetVelocity*>(bValues->GetIolets()[boundaryId]);
             LatticePosition sitePos(site.GetGlobalSiteCoords());
+            Direction unstreamed = LatticeType::INVERSEDIRECTIONS[ii];
 
             // Couple with an external system if there is
-						iolet->DoPreStreamCoupling(site.GetIndex(), bValues->GetTimeStep(), site.GetGlobalSiteCoords(),
-														           hydroVars.density, hydroVars.velocity);
+            if (unstreamed == ii)
+            {
+						  iolet->DoPreStreamCoupling(site.GetIndex(), bValues->GetTimeStep(), sitePos,
+							  							           hydroVars.density, hydroVars.velocity);
+            }
 
             LatticePosition halfWay(sitePos);
             halfWay.x += 0.5 * LatticeType::CX[ii];
@@ -78,14 +87,43 @@ namespace hemelb
 
           inline void PostStepLink(geometry::LatticeData* const latticeData,
 							const geometry::Site<geometry::LatticeData>& site,
-							const Direction& direction)
+							const Direction& ii)
 					{
 						int boundaryId = site.GetIoletId();
 						iolets::InOutLet* localIOlet = bValues->GetIolets()[boundaryId];
+            Direction unstreamed = LatticeType::INVERSEDIRECTIONS[ii];
 
 						// Finalise the coupling with the external system
-						localIOlet->DoPostStreamCoupling(site.GetIndex(), bValues->GetTimeStep(), site.GetGlobalSiteCoords());
+            if (unstreamed == ii)
+            {
+						  localIOlet->DoPostStreamCoupling(site.GetIndex(), bValues->GetTimeStep(), site.GetGlobalSiteCoords());
+            }
 					}
+
+        protected:
+          // Copied from YangPressureDelegate
+					void SortDirectionsCloseToIOletNormal(iolets::InOutLet* localIOlet)
+					{
+						const LatticePosition& ioletNormal = localIOlet->GetNormal();
+						std::array<Direction, LatticeType::NUMVECTORS> dirs;
+        		std::array<LatticeDistance, LatticeType::NUMVECTORS> dist;
+
+	        	for (Direction k = 0; k < LatticeType::NUMVECTORS; ++k)
+						{
+							const LatticePosition ck = LatticePosition(LatticeType::CXD[k],
+					          							                       LatticeType::CYD[k],
+		                													           LatticeType::CZD[k]);
+							const LatticePosition unitCk = ck.GetNormalised();
+							dist[k] = LatticePosition(unitCk - ioletNormal).GetMagnitudeSquared();
+        			dirs[k] = k;
+      			}
+
+						// Sort dirs by comparing any two elements of dist.
+      			std::sort(dirs.begin(), dirs.end(), [&dist](Direction i, Direction j) {return dist[i] < dist[j];});
+
+						// Store the results in the iolet object.
+						localIOlet->SetDirectionsCloseToNormal(dirs.begin(), dirs.end());
+      		}
 
         private:
           iolets::BoundaryValues* bValues;

--- a/src/lb/streamers/NashZerothOrderPressureDelegate.h
+++ b/src/lb/streamers/NashZerothOrderPressureDelegate.h
@@ -38,7 +38,7 @@ namespace hemelb
 						iolets::InOutLet* localIOlet = iolet.GetIolets()[boundaryId];
 
 						// Couple with an external system if there is
-						localIOlet->DoPreStreamCoupling(site.GetIndex(), site.GetGlobalSiteCoords(),
+						localIOlet->DoPreStreamCoupling(site.GetIndex(), iolet.GetTimeStep(), site.GetGlobalSiteCoords(),
 														hydroVars.density, hydroVars.velocity);
 
 						// Set the density at the "ghost" site to be the density of the iolet.
@@ -76,7 +76,7 @@ namespace hemelb
 						iolets::InOutLet* localIOlet = iolet.GetIolets()[boundaryId];
 
 						// Finalise the coupling with the external system
-						localIOlet->DoPostStreamCoupling(site.GetIndex(), site.GetGlobalSiteCoords());
+						localIOlet->DoPostStreamCoupling(site.GetIndex(), iolet.GetTimeStep(), site.GetGlobalSiteCoords());
 					}
 
 				protected:

--- a/src/lb/streamers/YangPressureDelegate.h
+++ b/src/lb/streamers/YangPressureDelegate.h
@@ -182,7 +182,7 @@ namespace hemelb
 					const LatticePosition& ioletNormal = localIOlet->GetNormal();
 
 					// Couple with an external system if there is
-					localIOlet->DoPreStreamCoupling(site.GetIndex(), site.GetGlobalSiteCoords(),
+					localIOlet->DoPreStreamCoupling(site.GetIndex(), iolet.GetTimeStep(), site.GetGlobalSiteCoords(),
 													hydroVars.density, hydroVars.velocity);
 
 					// Obtain cp, wallDistance, and the old distributions at the first and second fluid nodes.
@@ -292,7 +292,7 @@ namespace hemelb
 					iolets::InOutLet* localIOlet = iolet.GetIolets()[boundaryId];
 
 					// Finalise the coupling with the external system
-					localIOlet->DoPostStreamCoupling(site.GetIndex(), site.GetGlobalSiteCoords());
+					localIOlet->DoPostStreamCoupling(site.GetIndex(), iolet.GetTimeStep(), site.GetGlobalSiteCoords());
 				}
 
 			protected:

--- a/src/lb/streamers/YangPressureDelegate.h
+++ b/src/lb/streamers/YangPressureDelegate.h
@@ -180,10 +180,15 @@ namespace hemelb
 				{
 					iolets::InOutLet* localIOlet = iolet.GetIolets()[site.GetIoletId()];
 					const LatticePosition& ioletNormal = localIOlet->GetNormal();
+					Direction unstreamed = LatticeType::INVERSEDIRECTIONS[direction];
+					Direction dirG = localIOlet->GetDirectionCloseToNormal(0);
 
 					// Couple with an external system if there is
-					localIOlet->DoPreStreamCoupling(site.GetIndex(), iolet.GetTimeStep(), site.GetGlobalSiteCoords(),
-													hydroVars.density, hydroVars.velocity);
+					if (unstreamed == dirG)
+					{
+						localIOlet->DoPreStreamCoupling(site.GetIndex(), iolet.GetTimeStep(), site.GetGlobalSiteCoords(),
+														hydroVars.density, hydroVars.velocity);
+					}
 
 					// Obtain cp, wallDistance, and the old distributions at the first and second fluid nodes.
 					// Here wall is referred to as the iolet plane.
@@ -207,8 +212,6 @@ namespace hemelb
 									  - wallDistance * hVsecondFluid.GetFNeq().f[i];
 					}
 
-					Direction unstreamed = LatticeType::INVERSEDIRECTIONS[direction];
-					Direction dirG = localIOlet->GetDirectionCloseToNormal(0);
 					LatticeVector cg = LatticeVector(LatticeType::CX[dirG], LatticeType::CY[dirG], LatticeType::CZ[dirG]);
 					distribn_t fNew;
 
@@ -290,9 +293,14 @@ namespace hemelb
 				{
 					int boundaryId = site.GetIoletId();
 					iolets::InOutLet* localIOlet = iolet.GetIolets()[boundaryId];
+					Direction unstreamed = LatticeType::INVERSEDIRECTIONS[direction];
+					Direction dirG = localIOlet->GetDirectionCloseToNormal(0);
 
 					// Finalise the coupling with the external system
-					localIOlet->DoPostStreamCoupling(site.GetIndex(), iolet.GetTimeStep(), site.GetGlobalSiteCoords());
+					if (unstreamed == dirG)
+					{
+						localIOlet->DoPostStreamCoupling(site.GetIndex(), iolet.GetTimeStep(), site.GetGlobalSiteCoords());
+					}
 				}
 
 			protected:

--- a/src/net/MpiCommunicator.cc
+++ b/src/net/MpiCommunicator.cc
@@ -105,6 +105,13 @@ namespace hemelb
 			return MpiCommunicator(newComm, true);
 		}
 
+		MpiCommunicator MpiCommunicator::CreateGroup(const MpiGroup& grp, const int& tag) const
+		{
+			MPI_Comm newComm;
+			HEMELB_MPI_CALL(MPI_Comm_create_group, (*commPtr, grp, tag, &newComm));
+			return MpiCommunicator(newComm, true);
+		}
+
 		void MpiCommunicator::Abort(int errCode) const
 		{
 			HEMELB_MPI_CALL(MPI_Abort, (*commPtr, errCode));

--- a/src/net/MpiCommunicator.h
+++ b/src/net/MpiCommunicator.h
@@ -57,6 +57,14 @@ namespace hemelb
 				MpiCommunicator Create(const MpiGroup& grp) const;
 
 				/**
+				 * Creates a new communicator - see MPI_COMM_CREATE_GROUP
+				 * @param grp which is a subset of the group of this communicator.
+				 * @param tag used to distinguish concurrent executions of this function at a proc.
+				 * @return New communicator.
+				 */
+				MpiCommunicator CreateGroup(const MpiGroup& grp, const int& tag) const;
+
+				/**
 				 * Allow implicit casts to MPI_Comm
 				 * @return The underlying MPI communicator.
 				 */


### PR DESCRIPTION
Following the improvement in the simulation results by accounting for the backflow in the outlets, the conservation of mass appears to be critical to the accuracy and stability of the Windkessel BC. Therefore, I implemented an integration of the flow rates at the outlets to enforce mass conservation. This was achieved by using the Reduce utility available in HemeLB. I tested the approach in three domains using up to ~4600 cores. The results were found to improve slightly, while the runtime of the simulation had negligible change.