### PR TITLE
Adapt Calculations of Stresses for MRT Model

### DIFF
--- a/src/configuration/SimConfig.cc
+++ b/src/configuration/SimConfig.cc
@@ -15,6 +15,9 @@
 #include "util/fileutils.h"
 #include "lb/InitialCondition.h"
 
+#define QUOTE_RAW(x) #x
+#define QUOTE_CONTENTS(x) QUOTE_RAW(x)
+
 namespace hemelb
 {
 	namespace configuration
@@ -157,6 +160,15 @@ namespace hemelb
 				totalTimeSteps += warmUpSteps;
 			}
 
+			// Required element for some kernels
+			const std::string hemeKernel = QUOTE_CONTENTS(HEMELB_KERNEL);
+			if (hemeKernel == "TRT" || hemeKernel == "MRT")
+			{
+				// <relaxation_parameter value="unsigned" units="lattice" />
+				const io::xml::Element rpEl = simEl.GetChildOrThrow("relaxation_parameter");
+				GetDimensionalValue(rpEl, "lattice", relaxationParameter);
+			}
+
 			// Required element
 			// <voxel_size value="float" units="m" />
 			const io::xml::Element vsEl = simEl.GetChildOrThrow("voxel_size");
@@ -230,8 +242,6 @@ namespace hemelb
 			const std::string& ioletTypeName = ioletEl.GetName();
 			std::string hemeIoletBC;
 
-#define QUOTE_RAW(x) #x
-#define QUOTE_CONTENTS(x) QUOTE_RAW(x)
 			if (ioletTypeName == "inlet")
 				hemeIoletBC = QUOTE_CONTENTS(HEMELB_INLET_BOUNDARY);
 			else if (ioletTypeName == "outlet")

--- a/src/configuration/SimConfig.h
+++ b/src/configuration/SimConfig.h
@@ -133,10 +133,6 @@ namespace hemelb
         {
           return warmUpSteps;
         }
-        distribn_t GetRelaxationParameter() const
-        {
-          return relaxationParameter;
-        }
         PhysicalTime GetTimeStepLength() const
         {
           return timeStepSeconds;
@@ -165,17 +161,20 @@ namespace hemelb
         {
           return colloidConfigPath;
         }
+        distribn_t GetRelaxationParameter() const
+        {
+          return relaxationParameter;
+        }
+        distribn_t GetElasticWallStiffness() const
+        {
+          return elasticWallStiffness;
+        }
+        distribn_t GetBoundaryVelocityRatio() const
+        {
+          return boundaryVelocityRatio;
+        }
 
-	distribn_t GetElasticWallStiffness() const
-	{
-	  return elasticWallStiffness;
-	}
-	
-	distribn_t GetBoundaryVelocityRatio() const
-	{
-	  return boundaryVelocityRatio;
-	}
-	/**
+        /**
          * True if the XML file has a section specifying colloids.
          * @return
          */
@@ -187,13 +186,12 @@ namespace hemelb
          */
         LatticeDensity GetInitialPressure() const;
 
-
         // Get the initial condtion config
         inline const ICConfig& GetInitialCondition() const {
-	  return icConfig;
-	}
+          return icConfig;
+        }
         
-	const util::UnitConverter& GetUnitConverter() const;
+        const util::UnitConverter& GetUnitConverter() const;
 
         /**
          * Return the configuration of various checks/test
@@ -316,8 +314,6 @@ namespace hemelb
         std::string mapFilePath;
         int latticeId;
 
-
-
         float maxVelocity;
         float maxStress;
         lb::StressTypes stressType;
@@ -338,14 +334,14 @@ namespace hemelb
         PhysicalTime timeStepSeconds;
         unsigned long totalTimeSteps;
         unsigned long warmUpSteps;
-        distribn_t relaxationParameter;
         PhysicalDistance voxelSizeMetres;
         PhysicalPosition geometryOriginMetres;
         util::UnitConverter* unitConverter;
-	ICConfig icConfig;
+        ICConfig icConfig;
 
-	distribn_t elasticWallStiffness;
-	distribn_t boundaryVelocityRatio;
+        distribn_t relaxationParameter;
+        distribn_t elasticWallStiffness;
+        distribn_t boundaryVelocityRatio;
     };
   }
 }

--- a/src/configuration/SimConfig.h
+++ b/src/configuration/SimConfig.h
@@ -338,7 +338,6 @@ namespace hemelb
         PhysicalPosition geometryOriginMetres;
         util::UnitConverter* unitConverter;
         ICConfig icConfig;
-
         distribn_t relaxationParameter;
         distribn_t elasticWallStiffness;
         distribn_t boundaryVelocityRatio;

--- a/src/configuration/SimConfig.h
+++ b/src/configuration/SimConfig.h
@@ -133,6 +133,10 @@ namespace hemelb
         {
           return warmUpSteps;
         }
+        distribn_t GetRelaxationParameter() const
+        {
+          return relaxationParameter;
+        }
         PhysicalTime GetTimeStepLength() const
         {
           return timeStepSeconds;
@@ -334,6 +338,7 @@ namespace hemelb
         PhysicalTime timeStepSeconds;
         unsigned long totalTimeSteps;
         unsigned long warmUpSteps;
+        distribn_t relaxationParameter;
         PhysicalDistance voxelSizeMetres;
         PhysicalPosition geometryOriginMetres;
         util::UnitConverter* unitConverter;

--- a/src/lb/LbmParameters.h
+++ b/src/lb/LbmParameters.h
@@ -26,19 +26,19 @@ namespace hemelb
     struct LbmParameters
     {
       public:
-        LbmParameters(PhysicalTime timeStepLength, PhysicalDistance voxelSize)
+        LbmParameters(PhysicalTime timeStepLength, PhysicalDistance voxelSize) :
+            timestep(timeStepLength), voxelSize(voxelSize)
         {
-          Update(timeStepLength, voxelSize);
+          tau = 0.5
+              + (timestep * BLOOD_VISCOSITY_Pa_s / BLOOD_DENSITY_Kg_per_m3)
+                  / (Cs2 * voxelSize * voxelSize);
+          omega = -1.0 / tau;
+          beta = -1.0 / (2.0 * tau);
         }
 
-        void Update(PhysicalTime timeStepLength, PhysicalDistance voxelSizeMetres)
+        void Update(const distribn_t& relaxationTime)
         {
-          timestep = timeStepLength;
-          voxelSize = voxelSizeMetres;
-          tau = 0.5
-              + (timeStepLength * BLOOD_VISCOSITY_Pa_s / BLOOD_DENSITY_Kg_per_m3)
-                  / (Cs2 * voxelSize * voxelSize);
-
+          tau = relaxationTime;
           omega = -1.0 / tau;
           beta = -1.0 / (2.0 * tau);
         }

--- a/src/lb/LbmParameters.h
+++ b/src/lb/LbmParameters.h
@@ -85,19 +85,17 @@ namespace hemelb
         }
 
         StressTypes StressType;
-        
-	distribn_t ElasticWallStiffness;
-	
-	distribn_t BoundaryVelocityRatio;
+        distribn_t ElasticWallStiffness;
+        distribn_t BoundaryVelocityRatio;
 
       private:
         PhysicalTime timestep;
         PhysicalDistance voxelSize;
         distribn_t omega;
         distribn_t tau;
-        distribn_t relaxationParameter;
         distribn_t stressParameter;
         distribn_t beta; ///< Viscous dissipation in ELBM
+        distribn_t relaxationParameter;
     };
   }
 }

--- a/src/lb/LbmParameters.h
+++ b/src/lb/LbmParameters.h
@@ -74,6 +74,16 @@ namespace hemelb
           return beta;
         }
 
+        // A parameter used in the relaxation of some collision operators.
+        void SetRelaxationParameter(const distribn_t& param)
+        {
+          relaxationParameter = param;
+        }
+        distribn_t GetRelaxationParameter() const
+        {
+          return relaxationParameter;
+        }
+
         StressTypes StressType;
         
 	distribn_t ElasticWallStiffness;
@@ -85,6 +95,7 @@ namespace hemelb
         PhysicalDistance voxelSize;
         distribn_t omega;
         distribn_t tau;
+        distribn_t relaxationParameter;
         distribn_t stressParameter;
         distribn_t beta; ///< Viscous dissipation in ELBM
     };

--- a/src/lb/LbmParameters.h
+++ b/src/lb/LbmParameters.h
@@ -40,7 +40,6 @@ namespace hemelb
                   / (Cs2 * voxelSize * voxelSize);
 
           omega = -1.0 / tau;
-          stressParameter = (1.0 - 1.0 / (2.0 * tau)) / sqrt(2.0);
           beta = -1.0 / (2.0 * tau);
         }
 
@@ -62,11 +61,6 @@ namespace hemelb
         distribn_t GetTau() const
         {
           return tau;
-        }
-
-        distribn_t GetStressParameter() const
-        {
-          return stressParameter;
         }
 
         distribn_t GetBeta() const
@@ -93,7 +87,6 @@ namespace hemelb
         PhysicalDistance voxelSize;
         distribn_t omega;
         distribn_t tau;
-        distribn_t stressParameter;
         distribn_t beta; ///< Viscous dissipation in ELBM
         distribn_t relaxationParameter;
     };

--- a/src/lb/kernels/BaseKernel.h
+++ b/src/lb/kernels/BaseKernel.h
@@ -112,7 +112,7 @@ namespace hemelb
 						fPostCollision[direction] = value;
 					}
 
-					inline const FVector<LatticeType>& GetFPostCollision()
+					inline const FVector<LatticeType>& GetFPostCollision() const
 					{
 						return fPostCollision;
 					}

--- a/src/lb/kernels/BaseKernel.h
+++ b/src/lb/kernels/BaseKernel.h
@@ -176,7 +176,7 @@ namespace hemelb
 
 					// The LB parameters object. Currently only used in LBGKNN to access the current
 					// time step.
-					const LbmParameters* lbmParams;
+					LbmParameters* lbmParams;
 
 					// The neighbouring data manager, for kernels / collisions / streamers that
 					// require data from other cores.

--- a/src/lb/kernels/MRT.h
+++ b/src/lb/kernels/MRT.h
@@ -157,7 +157,7 @@ namespace hemelb
            */
           void InitState(const InitParams& initParams)
           {
-            MomentBasis::SetUpCollisionMatrix(collisionMatrix, initParams.lbmParams->GetTau());
+            MomentBasis::SetUpCollisionMatrix(collisionMatrix, initParams.lbmParams->GetRelaxationParameter());
           }
 
       };

--- a/src/lb/kernels/MRT.h
+++ b/src/lb/kernels/MRT.h
@@ -157,6 +157,7 @@ namespace hemelb
            */
           void InitState(const InitParams& initParams)
           {
+            initParams.lbmParams->Update(1.0 / initParams.lbmParams->GetRelaxationParameter());
             MomentBasis::SetUpCollisionMatrix(collisionMatrix, initParams.lbmParams->GetRelaxationParameter());
           }
 

--- a/src/lb/kernels/TRT.h
+++ b/src/lb/kernels/TRT.h
@@ -83,9 +83,7 @@ namespace hemelb
             // Magic number determines the other relaxation time
             // Lambda = (tau_plus - 1/2) (tau_minus - 1/2)
             // Choose such that HWBB walls are always in the right place.
-            // TODO: make this a configurable parameter.
-            const distribn_t Lambda = 3.0 / 16.0;
-
+            const distribn_t Lambda = lbmParams->GetRelaxationParameter();
             const distribn_t tau_plus = lbmParams->GetTau();
             const distribn_t omega_plus = lbmParams->GetOmega();
             const distribn_t tau_minus = 0.5 + Lambda / (tau_plus - 0.5);

--- a/src/lb/kernels/momentBasis/DHumieresD3Q15MRTBasis.cc
+++ b/src/lb/kernels/momentBasis/DHumieresD3Q15MRTBasis.cc
@@ -54,20 +54,20 @@ namespace hemelb
         }
 
         void DHumieresD3Q15MRTBasis::SetUpCollisionMatrix(std::vector<distribn_t>& collisionMatrix,
-                                                          distribn_t tau)
+                                                          distribn_t relaxationTime)
         {
-          // Relaxation values taken from d'Humieres 2002, except for the kinematic viscosity where the usual tau formula is used.
+          // Relaxation values taken from d'Humieres 2002.
           collisionMatrix.clear();
           collisionMatrix.push_back(1.6); // e (s1)
           collisionMatrix.push_back(1.2); // epsilon (s2)
           collisionMatrix.push_back(1.6); // q_x (s4)
           collisionMatrix.push_back(1.6); // q_y (s4)
           collisionMatrix.push_back(1.6); // q_z (s4)
-          collisionMatrix.push_back(1.0 / tau); // 3p_xx (s9)
-          collisionMatrix.push_back(1.0 / tau); // p_ww (s9)
-          collisionMatrix.push_back(1.0 / tau); // p_xy (s11 = s9)
-          collisionMatrix.push_back(1.0 / tau); // p_yz (s11 = s9)
-          collisionMatrix.push_back(1.0 / tau); // p_zx (s11 = s9)
+          collisionMatrix.push_back(relaxationTime); // 3p_xx (s9)
+          collisionMatrix.push_back(relaxationTime); // p_ww (s9)
+          collisionMatrix.push_back(relaxationTime); // p_xy (s11 = s9)
+          collisionMatrix.push_back(relaxationTime); // p_yz (s11 = s9)
+          collisionMatrix.push_back(relaxationTime); // p_zx (s11 = s9)
           collisionMatrix.push_back(1.2); // m_xyz (s14)
           assert(collisionMatrix.size() == DHumieresD3Q15MRTBasis::NUM_KINETIC_MOMENTS);
         }

--- a/src/lb/kernels/momentBasis/DHumieresD3Q15MRTBasis.h
+++ b/src/lb/kernels/momentBasis/DHumieresD3Q15MRTBasis.h
@@ -51,9 +51,9 @@ namespace hemelb
              * Sets up the MRT collision matrix \hat{S}
              *
              * @param collisionMatrix MRT collision matrix, diagonal
-             * @param tau LB relaxation time used to relax some of the moments
+             * @param relaxationTime LB relaxation time used to relax some of the moments
              */
-            static void SetUpCollisionMatrix(std::vector<distribn_t>& collisionMatrix, distribn_t tau);
+            static void SetUpCollisionMatrix(std::vector<distribn_t>& collisionMatrix, distribn_t relaxationTime);
         };
       }
     }

--- a/src/lb/kernels/momentBasis/DHumieresD3Q19MRTBasis.cc
+++ b/src/lb/kernels/momentBasis/DHumieresD3Q19MRTBasis.cc
@@ -60,22 +60,23 @@ namespace hemelb
           }
         }
 
-        void DHumieresD3Q19MRTBasis::SetUpCollisionMatrix(std::vector<distribn_t>& collisionMatrix, distribn_t tau)
+        void DHumieresD3Q19MRTBasis::SetUpCollisionMatrix(std::vector<distribn_t>& collisionMatrix,
+                                                          distribn_t relaxationTime)
         {
-          // Relaxation values taken from d'Humieres 2002, except for the kinematic viscosity where the usual tau formula is used.
+          // Relaxation values taken from d'Humieres 2002.
           collisionMatrix.clear();
           collisionMatrix.push_back(1.19); // e (s1)
           collisionMatrix.push_back(1.4); // epsilon (s2)
           collisionMatrix.push_back(1.2); // q_x (s4)
           collisionMatrix.push_back(1.2); // q_y (s4)
           collisionMatrix.push_back(1.2); // q_z (s4)
-          collisionMatrix.push_back(1.0 / tau); // 3p_xx (s9)
+          collisionMatrix.push_back(relaxationTime); // 3p_xx (s9)
           collisionMatrix.push_back(1.4); // 3pi_xx s10
-          collisionMatrix.push_back(1.0 / tau); // 3p_ww (s9)
+          collisionMatrix.push_back(relaxationTime); // 3p_ww (s9)
           collisionMatrix.push_back(1.4); // 3pi_ww s10
-          collisionMatrix.push_back(1.0 / tau); // p_xy (s13 = s9)
-          collisionMatrix.push_back(1.0 / tau); // p_yz (s13 = s9)
-          collisionMatrix.push_back(1.0 / tau); // p_xz (s13 = s9)
+          collisionMatrix.push_back(relaxationTime); // p_xy (s13 = s9)
+          collisionMatrix.push_back(relaxationTime); // p_yz (s13 = s9)
+          collisionMatrix.push_back(relaxationTime); // p_xz (s13 = s9)
           collisionMatrix.push_back(1.98); // m_x (s16)
           collisionMatrix.push_back(1.98); // m_y (s16)
           collisionMatrix.push_back(1.98); // m_z (s16)

--- a/src/lb/kernels/momentBasis/DHumieresD3Q19MRTBasis.h
+++ b/src/lb/kernels/momentBasis/DHumieresD3Q19MRTBasis.h
@@ -51,9 +51,9 @@ namespace hemelb
              * Sets up the MRT collision matrix \hat{S}
              *
              * @param collisionMatrix MRT collision matrix, diagonal
-             * @param tau LB relaxation time used to relax some of the moments
+             * @param relaxationTime LB relaxation time used to relax some of the moments
              */
-            static void SetUpCollisionMatrix(std::vector<distribn_t>& collisionMatrix, distribn_t tau);
+            static void SetUpCollisionMatrix(std::vector<distribn_t>& collisionMatrix, distribn_t relaxationTime);
         };
       }
     }

--- a/src/lb/lattices/Lattice.h
+++ b/src/lb/lattices/Lattice.h
@@ -1134,6 +1134,7 @@ inline static double hsum_double_avx512(__m512d v) {
 							stress = sqrt(square_stress_vector - normal_stress * normal_stress);
 						}
 
+						// This method computes the sum of squared element of the strain rate tensor.
 						inline static distribn_t CalculateShearRate(const distribn_t &iTau,
 								const distribn_t fPostCollision[],
 								const distribn_t f[],
@@ -1148,8 +1149,8 @@ inline static double hsum_double_avx512(__m512d v) {
 									shear_rate += pi[row][column] * pi[row][column];
 								}
 							}
-							shear_rate = sqrt(shear_rate) / (-2.0 * iTau * Cs2 * iDensity);
-							shear_rate /= (1.0 - 1.0 / (2.0 * iTau));
+							shear_rate = sqrt(shear_rate) / (-2.0 * Cs2 * iDensity);
+							shear_rate /= iTau - 0.5;
 							return shear_rate;
 						}
 

--- a/src/lb/lattices/Lattice.h
+++ b/src/lb/lattices/Lattice.h
@@ -1078,9 +1078,9 @@ inline static double hsum_double_avx512(__m512d v) {
 						/**
 						 * Calculate the full stress tensor at a given fluid site (including both pressure and deviatoric part)
 						 *
-						 * The stress tensor is assembled based on the formula:
+						 * The stress tensor is assembled based on the formula (Ferziger et al., 2020):
 						 *
-						 *    \sigma = p*I + 2*\mu*S = p*I - \Pi^{(neq)}
+						 *    \sigma = -p*I + 2*\mu*S = -p*I - \Pi^{(neq)}
 						 *
 						 * where p is hydrodynamic pressure, I is the identity tensor, S is the strain rate tensor, and \mu is the
 						 * viscosity. -2*\mu*S can be shown to be equals to the non equilibrium part of the moment flux tensor \Pi^{(neq)}.
@@ -1102,14 +1102,14 @@ inline static double hsum_double_avx512(__m512d v) {
 						{
 							// Initialises the stress tensor to the deviatoric part, i.e. -\Pi^{(neq)}
 							stressTensor = CalculatePiTensor(fNonEquilibrium);
-							stressTensor *= 1 - 1 / (2 * tau);
+							stressTensor *= -(1.0 - 1.0 / (2.0 * tau));
 
-							// Add the pressure component to the stress tensor. The reference pressure given
+							// Subtract the pressure component from the stress tensor. The reference pressure given
 							// by the REFERENCE_PRESSURE_mmHg constant is mapped to rho=1. Here we subtract 1
 							// and when the tensor is turned into physical units REFERENCE_PRESSURE_mmHg will
 							// be added.
 							LatticePressure pressure = (density - 1) * Cs2;
-							stressTensor.addDiagonal(pressure);
+							stressTensor.addDiagonal(-pressure);
 						}
 
 						/**
@@ -1146,7 +1146,7 @@ inline static double hsum_double_avx512(__m512d v) {
 							// of the moment flux tensor pi.
 							distribn_t temp = iStressParameter * (-sqrt(2.0));
 
-							// Computes the second moment of the equilibrium function f.
+							// Computes the second moment of the non-equilibrium function f.
 							util::Matrix3D pi = CalculatePiTensor(f);
 
 							for (unsigned i = 0; i < 3; i++)

--- a/src/lb/lb.hpp
+++ b/src/lb/lb.hpp
@@ -360,7 +360,6 @@ namespace hemelb
 				inletCount = inlets.size();
 				outletCount = outlets.size();
 				mParams.StressType = mSimConfig->GetStressType();
-
 				mParams.SetRelaxationParameter(mSimConfig->GetRelaxationParameter());
 				mParams.ElasticWallStiffness = mSimConfig->GetElasticWallStiffness();
 				mParams.BoundaryVelocityRatio = mSimConfig->GetBoundaryVelocityRatio();

--- a/src/lb/lb.hpp
+++ b/src/lb/lb.hpp
@@ -361,6 +361,7 @@ namespace hemelb
 				outletCount = outlets.size();
 				mParams.StressType = mSimConfig->GetStressType();
 
+				mParams.SetRelaxationParameter(mSimConfig->GetRelaxationParameter());
 				mParams.ElasticWallStiffness = mSimConfig->GetElasticWallStiffness();
 				mParams.BoundaryVelocityRatio = mSimConfig->GetBoundaryVelocityRatio();
 			}

--- a/src/lb/streamers/BaseStreamer.h
+++ b/src/lb/streamers/BaseStreamer.h
@@ -111,10 +111,10 @@ namespace hemelb
 									else
 									{
 										LatticeType::CalculateWallShearStressMagnitude(hydroVars.density,
+												hydroVars.tau,
 												hydroVars.GetFNeq().f,
 												site.GetWallNormal(),
-												stress,
-												lbmParams->GetStressParameter());
+												stress);
 									}
 
 									propertyCache.wallShearStressMagnitudeCache.Put(site.GetIndex(), stress);
@@ -123,9 +123,9 @@ namespace hemelb
 								if (propertyCache.vonMisesStressCache.RequiresRefresh())
 								{
 									distribn_t stress;
-									StreamerImpl::CollisionType::CKernel::LatticeType::CalculateVonMisesStress(hydroVars.GetFNeq().f,
-											stress,
-											lbmParams->GetStressParameter());
+									StreamerImpl::CollisionType::CKernel::LatticeType::CalculateVonMisesStress(hydroVars.tau,
+											hydroVars.GetFNeq().f,
+											stress);
 
 									propertyCache.vonMisesStressCache.Put(site.GetIndex(), stress);
 								}

--- a/src/lb/streamers/BaseStreamer.h
+++ b/src/lb/streamers/BaseStreamer.h
@@ -112,7 +112,8 @@ namespace hemelb
 									{
 										LatticeType::CalculateWallShearStressMagnitude(hydroVars.density,
 												hydroVars.tau,
-												hydroVars.GetFNeq().f,
+												hydroVars.GetFPostCollision().f,
+												hydroVars.f,
 												site.GetWallNormal(),
 												stress);
 									}
@@ -124,7 +125,8 @@ namespace hemelb
 								{
 									distribn_t stress;
 									StreamerImpl::CollisionType::CKernel::LatticeType::CalculateVonMisesStress(hydroVars.tau,
-											hydroVars.GetFNeq().f,
+											hydroVars.GetFPostCollision().f,
+											hydroVars.f,
 											stress);
 
 									propertyCache.vonMisesStressCache.Put(site.GetIndex(), stress);
@@ -134,7 +136,8 @@ namespace hemelb
 								{
 									distribn_t shear_rate =
 										StreamerImpl::CollisionType::CKernel::LatticeType::CalculateShearRate(hydroVars.tau,
-												hydroVars.GetFNeq().f,
+												hydroVars.GetFPostCollision().f,
+												hydroVars.f,
 												hydroVars.density);
 
 									propertyCache.shearRateCache.Put(site.GetIndex(), shear_rate);
@@ -145,7 +148,8 @@ namespace hemelb
 									util::Matrix3D stressTensor;
 									StreamerImpl::CollisionType::CKernel::LatticeType::CalculateStressTensor(hydroVars.density,
 											hydroVars.tau,
-											hydroVars.GetFNeq().f,
+											hydroVars.GetFPostCollision().f,
+											hydroVars.f,
 											stressTensor);
 
 									propertyCache.stressTensorCache.Put(site.GetIndex(), stressTensor);
@@ -163,7 +167,8 @@ namespace hemelb
 									{
 										LatticeType::CalculateTractionOnAPoint(hydroVars.density,
 												hydroVars.tau,
-												hydroVars.GetFNeq().f,
+												hydroVars.GetFPostCollision().f,
+												hydroVars.f,
 												site.GetWallNormal(),
 												tractionOnAPoint);
 									}
@@ -183,7 +188,8 @@ namespace hemelb
 									{
 										LatticeType::CalculateTangentialProjectionTraction(hydroVars.density,
 												hydroVars.tau,
-												hydroVars.GetFNeq().f,
+												hydroVars.GetFPostCollision().f,
+												hydroVars.f,
 												site.GetWallNormal(),
 												tangentialProjectionTractionOnAPoint);
 									}


### PR DESCRIPTION
The current calculations of stresses are valid for single-relaxation-time models only. The proposed changes adapt these calculations for the MRT model. This is achieved by applying a general equation to the computation of the momentum flux tensor and making it central to all calculations of stresses. The general equation is based on the Chai formula reviewed by Zhang et al ([2018](https://www.sciencedirect.com/science/article/pii/S089812211830035X?via%3Dihub)).

In addition, the magic parameter in the TRT model and the free relaxation parameter in the MRT model are made configurable.

The stresses calculated using the MRT in this new version are very close to those calculated using the LBGK model in simple tests.