### PR TITLE
Advancement of Pull Request #10

### DIFF
--- a/src/configuration/SimConfig.cc
+++ b/src/configuration/SimConfig.cc
@@ -600,6 +600,10 @@ namespace hemelb
 			{
 				field.type = extraction::OutputField::TangentialProjectionTraction;
 			}
+			else if (type == "normalprojectiontraction")
+			{
+				field.type = extraction::OutputField::NormalProjectionTraction;
+			}
 			else if (type == "wallextension")
 			{
 				field.type = extraction::OutputField::WallExtension;

--- a/src/extraction/IterableDataSource.h
+++ b/src/extraction/IterableDataSource.h
@@ -104,6 +104,12 @@ namespace hemelb
 				virtual util::Vector3D<PhysicalStress> GetTangentialProjectionTraction() const = 0;
 
 				/**
+				 * Returns the normal component the traction vector of a wall site.
+				 * @return projected traction vector
+				 */
+				virtual util::Vector3D<PhysicalStress> GetNormalProjectionTraction() const = 0;
+
+				/**
 				 * Returns the IOlet ID of the site.
 				 * @return IOlet ID
 				 */

--- a/src/extraction/LbDataSourceIterator.cc
+++ b/src/extraction/LbDataSourceIterator.cc
@@ -77,6 +77,11 @@ namespace hemelb
 			return converter.ConvertStressToPhysicalUnits(propertyCache.tangentialProjectionTractionCache.Get(position));
 		}
 
+		util::Vector3D<PhysicalStress> LbDataSourceIterator::GetNormalProjectionTraction() const
+		{
+			return converter.ConvertStressToPhysicalUnits(propertyCache.normalProjectionTractionCache.Get(position));
+		}
+
 		FloatingType LbDataSourceIterator::GetWallExtension() const
 		{
 			return converter.ConvertDistanceToPhysicalUnits(propertyCache.wallExtensionCache.Get(position));

--- a/src/extraction/LbDataSourceIterator.h
+++ b/src/extraction/LbDataSourceIterator.h
@@ -105,6 +105,12 @@ namespace hemelb
 				util::Vector3D<PhysicalStress> GetTangentialProjectionTraction() const;
 
 				/**
+				 * Returns the normal component of the traction vector of a wall site.
+				 * @return projected traction vector
+				 */
+				util::Vector3D<PhysicalStress> GetNormalProjectionTraction() const;
+
+				/**
 				 * Returns the IOlet ID of the site.
 				 * @return IOlet ID
 				 */

--- a/src/extraction/LocalPropertyOutput.cc
+++ b/src/extraction/LocalPropertyOutput.cc
@@ -294,6 +294,12 @@ namespace hemelb
                     << static_cast<WrittenDataType> (dataSource.GetTangentialProjectionTraction().y)
                     << static_cast<WrittenDataType> (dataSource.GetTangentialProjectionTraction().z);
                 break;
+              case OutputField::NormalProjectionTraction:
+                xdrWriter
+                    << static_cast<WrittenDataType> (dataSource.GetNormalProjectionTraction().x)
+                    << static_cast<WrittenDataType> (dataSource.GetNormalProjectionTraction().y)
+                    << static_cast<WrittenDataType> (dataSource.GetNormalProjectionTraction().z);
+                break;
               case OutputField::WallExtension:
                 xdrWriter
                     << static_cast<WrittenDataType> (dataSource.GetWallExtension());
@@ -372,6 +378,7 @@ namespace hemelb
         case OutputField::Velocity:
         case OutputField::Traction:
         case OutputField::TangentialProjectionTraction:
+        case OutputField::NormalProjectionTraction:
           return 3;
         case OutputField::StressTensor:
           return 6; // We only store the upper triangular part of the symmetric tensor

--- a/src/extraction/OutputField.h
+++ b/src/extraction/OutputField.h
@@ -24,6 +24,7 @@ namespace hemelb
           StressTensor,
           Traction,
           TangentialProjectionTraction,
+          NormalProjectionTraction,
 	        WallExtension,
 	  Distributions,
 	  MpiRank

--- a/src/extraction/PropertyActor.cc
+++ b/src/extraction/PropertyActor.cc
@@ -69,6 +69,9 @@ namespace hemelb
               case OutputField::TangentialProjectionTraction:
                 propertyCache.tangentialProjectionTractionCache.SetRefreshFlag();
                 break;
+              case OutputField::NormalProjectionTraction:
+                propertyCache.normalProjectionTractionCache.SetRefreshFlag();
+                break;
               case OutputField::WallExtension:
                 propertyCache.wallExtensionCache.SetRefreshFlag();
                 break;

--- a/src/geometry/LatticeData.cc
+++ b/src/geometry/LatticeData.cc
@@ -240,7 +240,7 @@ namespace hemelb
 					}
 
 					const util::Vector3D<float>& normal = blockReadIn.Sites[localSiteId].wallNormalAvailable ?
-						blockReadIn.Sites[localSiteId].wallNormal :
+						blockReadIn.Sites[localSiteId].wallNormal.GetNormalised() :
 						util::Vector3D<float>(NO_VALUE);
 
 					forceAtSite.push_back(LatticeForceVector(0, 0, 0));

--- a/src/lb/MacroscopicPropertyCache.cc
+++ b/src/lb/MacroscopicPropertyCache.cc
@@ -20,6 +20,7 @@ namespace hemelb
       stressTensorCache(simState, latticeData.GetLocalFluidSiteCount()),
       tractionCache(simState, latticeData.GetLocalFluidSiteCount()),
       tangentialProjectionTractionCache(simState, latticeData.GetLocalFluidSiteCount()),
+      normalProjectionTractionCache(simState, latticeData.GetLocalFluidSiteCount()),
       wallExtensionCache(simState, latticeData.GetLocalFluidSiteCount()),
       siteCount(latticeData.GetLocalFluidSiteCount())
     {
@@ -36,6 +37,7 @@ namespace hemelb
       stressTensorCache.UnsetRefreshFlag();
       tractionCache.UnsetRefreshFlag();
       tangentialProjectionTractionCache.UnsetRefreshFlag();
+      normalProjectionTractionCache.UnsetRefreshFlag();
       wallExtensionCache.UnsetRefreshFlag();
     }
 

--- a/src/lb/MacroscopicPropertyCache.h
+++ b/src/lb/MacroscopicPropertyCache.h
@@ -84,6 +84,11 @@ namespace hemelb
         util::RefreshableCache<util::Vector3D<LatticeStress> > tangentialProjectionTractionCache;
 
         /**
+         * The cache of normal component of the traction vectors of each fluid site on this core.
+         */
+        util::RefreshableCache<util::Vector3D<LatticeStress> > normalProjectionTractionCache;
+
+        /**
          * The cache of elastic wall extension of each fluid site on this core.
          */
         util::RefreshableCache<distribn_t> wallExtensionCache;

--- a/src/lb/lattices/Lattice.h
+++ b/src/lb/lattices/Lattice.h
@@ -1057,6 +1057,27 @@ inline static double hsum_double_avx512(__m512d v) {
 						}
 
 						/**
+						 * Calculates the normal component of the traction vector with respect to the wall surface.
+						 *
+						 * @param density density at a given site
+						 * @param tau relaxation time
+						 * @param fPostCollision post-collision distribution function
+						 * @param f distribution function
+						 * @param wallNormal wall normal at a given point
+						 * @param tractionNormalComponent normal projection of the traction vector
+						 */
+						inline static void CalculateNormalProjectionTraction(
+								const distribn_t density, const distribn_t tau, const distribn_t fPostCollision[],
+								const distribn_t f[],
+								const util::Vector3D<Dimensionless>& wallNormal,
+								util::Vector3D<LatticeStress>& tractionNormalComponent)
+						{
+							util::Vector3D<LatticeStress> traction;
+							CalculateTractionOnAPoint(density, tau, fPostCollision, f, wallNormal, traction);
+							tractionNormalComponent = wallNormal * traction.Dot(wallNormal);
+						}
+
+						/**
 						 * Calculate the full stress tensor at a given fluid site (including both pressure and deviatoric part)
 						 *
 						 * The stress tensor is assembled based on the formula (Ferziger et al., 2020):

--- a/src/lb/lattices/Lattice.h
+++ b/src/lb/lattices/Lattice.h
@@ -1310,17 +1310,17 @@ inline static double hsum_double_avx512(__m512d v) {
 						 *
 						 * where \mu is the dynamic viscosity.
 						 *
-						 * For the LBGK and MRT models, S is given by (Zhang et al., 2018)
+						 * For the LBGK and MRT models, S is given by (Chai et al., 2011)
 						 *
-						 *    S = \sum_i e_i e_i \Omega_i / (2*\rho_0*Cs2),
+						 *    S = \sum_i e_i e_i \Omega_i / (2*\rho*Cs2),
 						 *
-						 * where e_i is the i-th direction vector, \Omega is the collision operator in the LB equation,
-						 * and \rho_0 is the reference density. Here \Omega is obtained by subtracting the distribution
-						 * function from the post-collision distribution function.
+						 * where e_i is the i-th direction vector, and \Omega is the collision operator in the LB
+						 * equation obtained by subtracting the distribution function from the post-collision
+						 * distribution function.
 						 *
 						 * The equation for the pi tensor is simplified by using the relation
 						 *
-						 *    \mu / (\rho_0*Cs2) = \tau - 0.5,
+						 *    \mu / (\rho*Cs2) = \tau - 0.5,
 						 *
 						 * where \tau is the relaxation time governing the viscosity. As a result,
 						 *

--- a/src/lb/streamers/BaseStreamer.h
+++ b/src/lb/streamers/BaseStreamer.h
@@ -197,6 +197,27 @@ namespace hemelb
 									propertyCache.tangentialProjectionTractionCache.Put(site.GetIndex(), tangentialProjectionTractionOnAPoint);
 								}
 
+								if (propertyCache.normalProjectionTractionCache.RequiresRefresh())
+								{
+									util::Vector3D<LatticeStress> normalProjectionTractionOnAPoint(0);
+
+									/*
+									 * Wall normals are only available at the sites marked as being at the domain edge.
+									 * For the sites in the fluid bulk, the traction vector will be 0.
+									 */
+									if (site.IsWall())
+									{
+										LatticeType::CalculateNormalProjectionTraction(hydroVars.density,
+												hydroVars.tau,
+												hydroVars.GetFPostCollision().f,
+												hydroVars.f,
+												site.GetWallNormal(),
+												normalProjectionTractionOnAPoint);
+									}
+
+									propertyCache.normalProjectionTractionCache.Put(site.GetIndex(), normalProjectionTractionOnAPoint);
+								}
+
 								if (propertyCache.wallExtensionCache.RequiresRefresh())
 								{
 									propertyCache.wallExtensionCache.Put(site.GetIndex(), hydroVars.wallExtension);

--- a/src/lb/streamers/YangPressureDelegate.h
+++ b/src/lb/streamers/YangPressureDelegate.h
@@ -491,10 +491,10 @@ namespace hemelb
 					distribn_t stress = 0;
 					for (Direction k = 0; k < LatticeType::NUMVECTORS; ++k)
 					{
-						stress += B_k(k, vec) * fNeq[k];
+						stress += B_k(k, vec) * (fNeq[k] + fNeq[LatticeType::INVERSEDIRECTIONS[k]]);
 					}
-					// Note that A_k = A_k* = 1/tau and h = 1 in lattice units.
-					stress *= -1.0 / tau;
+					// Note that h = 1 in lattice units.
+					stress *= -1.0 / (2.0 * tau);
 					return stress;
 				}
 

--- a/src/util/UnitConverter.h
+++ b/src/util/UnitConverter.h
@@ -73,13 +73,13 @@ namespace hemelb
         Matrix3D ConvertFullStressTensorToPhysicalUnits(Matrix3D stressTensor) const
         {
           Matrix3D ret = stressTensor * latticePressure;
-          ret.addDiagonal(REFERENCE_PRESSURE_mmHg * mmHg_TO_PASCAL);
+          ret.addDiagonal(-REFERENCE_PRESSURE_mmHg * mmHg_TO_PASCAL);
           return ret;
         }
 
         /**
          * Convert a traction vector (force per unit area) to physical units. Note how a
-         * REFERENCE_PRESSURE_mmHg*wallNormal component is added to account for the reference
+         * REFERENCE_PRESSURE_mmHg*wallNormal component is subtracted to account for the reference
          * pressure that was removed when converting the simulation input to lattice units.
          *
          * @param traction traction vector (computed the full stress tensor)
@@ -91,7 +91,7 @@ namespace hemelb
                                                             const Vector3D<Dimensionless>& wallNormal) const
         {
           Vector3D<VectorType> ret = traction * (latticeSpeed * latticeSpeed * BLOOD_DENSITY_Kg_per_m3);
-          ret += wallNormal * REFERENCE_PRESSURE_mmHg * mmHg_TO_PASCAL;
+          ret -= wallNormal * REFERENCE_PRESSURE_mmHg * mmHg_TO_PASCAL;
           return ret;
         }
 


### PR DESCRIPTION
First, the stress function of Yang pressure BC is amended to include the distribution function in the inverse direction. This does not affect the implementation of models with a single relaxation time due to the symmetry of the collision matrix; however, it makes the equation explicit and the adaptations for other models in the future easier.

Second, the amendment of the unit conversion of stresses was missed when the calculation of the full stress tensor was rectified in Pull Request #10. Here a remedy is implemented.

Third, the wall normals read from the geometry file are normalised explicitly to ensure they are unit vectors.

Fourth, the calculation of the normal stress is added.