### PR TITLE
Corrections in the Windkessel Model

### DIFF
--- a/src/lb/iolets/InOutLet.h
+++ b/src/lb/iolets/InOutLet.h
@@ -57,7 +57,7 @@ namespace hemelb
       {
         public:
           InOutLet() :
-            comms(NULL), extraData(NULL)
+            comms(NULL), extraData(NULL), centreSiteID(-1)
           {
           }
           virtual ~InOutLet()

--- a/src/lb/iolets/InOutLetFileWK.cc
+++ b/src/lb/iolets/InOutLetFileWK.cc
@@ -19,7 +19,7 @@ namespace hemelb
     namespace iolets
     {
       InOutLetFileWK::InOutLetFileWK() :
-          InOutLetWK(), area(1.0), units(NULL)
+          InOutLetWK(), units(NULL)
       {
       }
 

--- a/src/lb/iolets/InOutLetFileWK.h
+++ b/src/lb/iolets/InOutLetFileWK.h
@@ -33,22 +33,11 @@ namespace hemelb
             wkWeightsFilePath = path;
           }
           
-          const distribn_t& GetArea() const
-          {
-            return area;
-          }
-
-          void SetArea(const distribn_t& a)
-          {
-            area = a;
-          }
-
           bool useWeightsFromFile;
 
           void Initialise(const util::UnitConverter* unitConverter);
         
         private:
-          distribn_t area;
           std::map<std::vector<int>, double> weights_table;
           std::string wkWeightsFilePath;
           const util::UnitConverter* units;

--- a/src/lb/iolets/InOutLetWK.h
+++ b/src/lb/iolets/InOutLetWK.h
@@ -127,6 +127,7 @@ namespace hemelb
           distribn_t area, resistance, capacitance;
           LatticeDensity density, densityNew;
           distribn_t flowRate, flowRateNew;
+          site_t siteCount;
       };
     }
   }


### PR DESCRIPTION
In the previous version, the area attribute in the WKfile outlet was not referenced correctly since it was declared twice. The proposed commits fix this issue.