### PR TITLE
Moving HasIolet to individual Delegates

### DIFF
--- a/src/lb/streamers/LaddIoletDelegate.h
+++ b/src/lb/streamers/LaddIoletDelegate.h
@@ -50,6 +50,8 @@ namespace hemelb
             // where u is the velocity of the boundary half way along the
             // link and a1_i = w_1 / cs2
 
+            if (!site.HasIolet(ii)) return;
+
             int boundaryId = site.GetIoletId();
             iolets::InOutLetVelocity* iolet =
                 dynamic_cast<iolets::InOutLetVelocity*>(bValues->GetIolets()[boundaryId]);
@@ -89,6 +91,8 @@ namespace hemelb
 							const geometry::Site<geometry::LatticeData>& site,
 							const Direction& ii)
 					{
+            if (!site.HasIolet(ii)) return;
+
 						int boundaryId = site.GetIoletId();
 						iolets::InOutLet* localIOlet = bValues->GetIolets()[boundaryId];
             Direction unstreamed = LatticeType::INVERSEDIRECTIONS[ii];

--- a/src/lb/streamers/NashZerothOrderPressureDelegate.h
+++ b/src/lb/streamers/NashZerothOrderPressureDelegate.h
@@ -39,6 +39,8 @@ namespace hemelb
 							kernels::HydroVars<typename CollisionType::CKernel>& hydroVars,
 							const Direction& direction)
 					{
+						if (!site.HasIolet(direction)) return;
+
 						int boundaryId = site.GetIoletId();
 						iolets::InOutLet* localIOlet = iolet.GetIolets()[boundaryId];
 						Direction unstreamed = LatticeType::INVERSEDIRECTIONS[direction];
@@ -79,6 +81,8 @@ namespace hemelb
 							const geometry::Site<geometry::LatticeData>& site,
 							const Direction& direction)
 					{
+						if (!site.HasIolet(direction)) return;
+
 						int boundaryId = site.GetIoletId();
 						iolets::InOutLet* localIOlet = iolet.GetIolets()[boundaryId];
 						Direction unstreamed = LatticeType::INVERSEDIRECTIONS[direction];

--- a/src/lb/streamers/StreamerTypeFactory.h
+++ b/src/lb/streamers/StreamerTypeFactory.h
@@ -158,14 +158,8 @@ namespace hemelb
 
 								for (Direction ii = 0; ii < LatticeType::NUMVECTORS; ii++)
 								{
-									if (site.HasIolet(ii))
-									{
-										ioletLinkDelegate.StreamLink(lbmParams, latDat, site, hydroVars, ii);
-									}
-									else
-									{
-										bulkLinkDelegate.StreamLink(lbmParams, latDat, site, hydroVars, ii);
-									}
+									bulkLinkDelegate.StreamLink(lbmParams, latDat, site, hydroVars, ii);
+									ioletLinkDelegate.StreamLink(lbmParams, latDat, site, hydroVars, ii);
 								}
 
 								//TODO: Necessary to specify sub-class?
@@ -188,10 +182,7 @@ namespace hemelb
 								geometry::Site<geometry::LatticeData> site = latticeData->GetSite(siteIndex);
 								for (unsigned int direction = 0; direction < LatticeType::NUMVECTORS; direction++)
 								{
-									if (site.HasIolet(direction))
-									{
-										ioletLinkDelegate.PostStepLink(latticeData, site, direction);
-									}
+									ioletLinkDelegate.PostStepLink(latticeData, site, direction);
 								}
 							}
 						}
@@ -252,11 +243,7 @@ namespace hemelb
 
 								for (Direction ii = 0; ii < LatticeType::NUMVECTORS; ii++)
 								{
-									if (site.HasIolet(ii))
-									{
-										ioletLinkDelegate.StreamLink(lbmParams, latDat, site, hydroVars, ii);
-									}
-									else if (site.HasWall(ii))
+									if (site.HasWall(ii))
 									{
 										wallLinkDelegate.StreamLink(lbmParams, latDat, site, hydroVars, ii);
 									}
@@ -264,6 +251,7 @@ namespace hemelb
 									{
 										bulkLinkDelegate.StreamLink(lbmParams, latDat, site, hydroVars, ii);
 									}
+									ioletLinkDelegate.StreamLink(lbmParams, latDat, site, hydroVars, ii);
 								}
 
 								//TODO: Necessary to specify sub-class?
@@ -290,10 +278,7 @@ namespace hemelb
 									{
 										wallLinkDelegate.PostStepLink(latticeData, site, direction);
 									}
-									else if (site.HasIolet(direction))
-									{
-										ioletLinkDelegate.PostStepLink(latticeData, site, direction);
-									}
+									ioletLinkDelegate.PostStepLink(latticeData, site, direction);
 								}
 							}
 						}

--- a/src/lb/streamers/YangPressureDelegate.h
+++ b/src/lb/streamers/YangPressureDelegate.h
@@ -179,6 +179,8 @@ namespace hemelb
 						   kernels::HydroVars<typename CollisionType::CKernel> &hydroVars,
 						   const Direction &direction)
 				{
+					if (!site.HasIolet(direction)) return;
+
 					iolets::InOutLet* localIOlet = iolet.GetIolets()[site.GetIoletId()];
 					const LatticePosition& ioletNormal = localIOlet->GetNormal();
 					Direction unstreamed = LatticeType::INVERSEDIRECTIONS[direction];
@@ -292,6 +294,8 @@ namespace hemelb
 						const geometry::Site<geometry::LatticeData>& site,
 						const Direction& direction)
 				{
+					if (!site.HasIolet(direction)) return;
+
 					int boundaryId = site.GetIoletId();
 					iolets::InOutLet* localIOlet = iolet.GetIolets()[boundaryId];
 					Direction unstreamed = LatticeType::INVERSEDIRECTIONS[direction];


### PR DESCRIPTION
The conditional for checking if the streaming direction is an iolet is moved inside the implementations of individual delegates so that boundary conditions that replace velocity distributions in all directions can be implemented.