### PR TITLE
Improvement of Yang Pressure BC

### DIFF
--- a/src/configuration/SimConfig.cc
+++ b/src/configuration/SimConfig.cc
@@ -908,7 +908,6 @@ namespace hemelb
 
 			velocityFilePath = util::NormalizePathRelativeToPath(velocityFilePath, xmlFilePath);
 			newIolet->SetFilePath(velocityFilePath);
-			std::cout << "path is here:" << velocityFilePath << std::endl;
 
 			const io::xml::Element radiusEl = conditionEl.GetChildOrThrow("radius");
 			newIolet->SetRadius(GetDimensionalValueInLatticeUnits<LatticeDistance>(radiusEl, "m"));

--- a/src/lb/iolets/InOutLetReadWriteVelocity.cc
+++ b/src/lb/iolets/InOutLetReadWriteVelocity.cc
@@ -50,7 +50,6 @@ namespace hemelb
 				if (siteCount != 0)
 				{
 					densityAvg = densityAvg / siteCount;
-					printf("densityAvg %.15lf, siteCount %ld\n", densityAvg, siteCount);
 				}
 
 				densitySum = 0.0;
@@ -331,7 +330,6 @@ namespace hemelb
 				else
 				{
 					weights_sum = 0.5 * area;
-					printf("weights_sum %.15lf\n", weights_sum);
 				}
 
 				struct stat infile;


### PR DESCRIPTION
In the original algorithm of Yang pressure BC, the extrapolation at the outer-neighbour node uses lattice data within two lattice units. However, the voxelised domain for HemeLB usually approximates a tilted plane with three layers of lattice sites. This renders the implemented Yang pressure BC futile. The proposed changes extend the extrapolation algorithm to use lattice data within three lattice units.

Moreover, the calculation of the wall distance is corrected by taking into account the width of the boundary plane.

In addition, I removed some print statements that I forgot to remove before a previous pull request.